### PR TITLE
Fix - Logging out of DCD and deleting account disconnects us from FC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: ["push"]
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: Tests (ruby: v${{ matrix.ruby }})
     strategy:
       matrix:
         ruby:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/lib/omniauth/strategies/france_connect.rb
+++ b/lib/omniauth/strategies/france_connect.rb
@@ -57,10 +57,13 @@ module OmniAuth
       end
 
       def end_session_uri
-        return unless client_options.end_session_endpoint.present?
+	if client_options.end_session_endpoint.blank?
+          log :debug, "Logout not set, to do so define 'end_session_endpoint'"
+          return
+        end
 
         end_session_uri = URI(options.issuer + client_options.end_session_endpoint)
-        session["omniauth_logout"] = end_session_uri
+        session["omniauth.france_connect.end_session_uri"] = end_session_uri
         end_session_uri.to_s
       end
 

--- a/lib/omniauth/strategies/france_connect.rb
+++ b/lib/omniauth/strategies/france_connect.rb
@@ -57,7 +57,7 @@ module OmniAuth
       end
 
       def end_session_uri
-	if client_options.end_session_endpoint.blank?
+        if client_options.end_session_endpoint.blank?
           log :debug, "Logout not set, to do so define 'end_session_endpoint'"
           return
         end

--- a/lib/omniauth/strategies/france_connect.rb
+++ b/lib/omniauth/strategies/france_connect.rb
@@ -60,7 +60,7 @@ module OmniAuth
         return unless client_options.end_session_endpoint.present?
 
         end_session_uri = URI(options.issuer + client_options.end_session_endpoint)
-        session['omniauth_logout'] = end_session_uri
+        session["omniauth_logout"] = end_session_uri
         end_session_uri.to_s
       end
 

--- a/lib/omniauth/strategies/france_connect.rb
+++ b/lib/omniauth/strategies/france_connect.rb
@@ -60,11 +60,7 @@ module OmniAuth
         return unless client_options.end_session_endpoint.present?
 
         end_session_uri = URI(options.issuer + client_options.end_session_endpoint)
-        end_session_uri.query = URI.encode_www_form(
-          id_token_hint: credentials[:id_token],
-          state: session_state,
-          post_logout_redirect_uri: "#{full_host}/users/auth/#{options.name}/logout"
-        )
+        session['omniauth_logout'] = end_session_uri
         end_session_uri.to_s
       end
 
@@ -86,13 +82,9 @@ module OmniAuth
           authorization_endpoint: "/api/v1/authorize",
           token_endpoint: "/api/v1/token",
           userinfo_endpoint: "/api/v1/userinfo",
-          jwks_uri: "/api/v1/jwk"
+          jwks_uri: "/api/v1/jwk",
+          end_session_endpoint: "/api/v1/logout"
         }
-
-        if options.end_session_endpoint.present?
-          client_options_hash[:end_session_endpoint] =
-            options.end_session_endpoint
-        end
 
         options.client_options.merge client_options_hash
       end

--- a/spec/omniauth/strategies/france_connect_spec.rb
+++ b/spec/omniauth/strategies/france_connect_spec.rb
@@ -37,7 +37,7 @@ module OmniAuth
       end
 
       it "returns default undefined end_session_endpoint" do
-        expect(subject.options.end_session_endpoint).to be_nil
+        expect(subject.options.end_session_endpoint).to eq("/api/v1/logout")
       end
 
       it "returns list of scope" do


### PR DESCRIPTION
### **WARNING ! This PR is linked to [DCD-App Changes](https://github.com/OpenSourcePolitics/decidim-app/pull/199) **

Hello ! I make this PR following my visual changes to fix the bug where logging out of DCD didn't logged us out of France Connect.

In this PR, I've just modified the strategy following what I've tested and that works.
First of all, I've put the link of disconnection in our client_options, as it will not change depending of our user.
Secondly, end_session_uri was containing some parameters that were not used, or not properly used in the link that was recommended to disconnect. And finally to link it with our rails front, I've decided to store our logout uri into a session variable that will contain the link and will permit us to use it to disconnect from both of the platforms.

I've decided to not change the code more than this, even if I probably could, because I'm not sure this will be the right solution and so I'll prefer to offer you some ways to find an other solution with what was developed earlier because I'm not sure I understood every aspect of it.

Don't mind asking me if you have few questions or change requests i'll be there for it.

#### Description 

* On login, France Connect logout URL is saved in session at `omniauth.france_connect.end_session_uri` and used on logout and destroy account sequence in decidim-app
* `end_session_endpoint` is set by default to `/api/v1/logout` but overridable in application initializer